### PR TITLE
Update pointers_2d_array_initialization.c

### DIFF
--- a/comp3001-master/profiling/pointers_2d_array_initialization.c
+++ b/comp3001-master/profiling/pointers_2d_array_initialization.c
@@ -79,7 +79,7 @@ printf("\n print_using_pointers2() is just called");
 
 for (i=0;i<N;i++)
  for (j=0;j<N;j++)
- printf("\n element %d equals to %d",i, *(ptr + i*N + j) );
+ printf("\n element (%d,%d) equals to %d", i, j, *(ptr + i*N + j) );
 
 printf("\n print_using_pointers2() is just ended\n\n");
 


### PR DESCRIPTION
Fixes the printf string and arguments for the second use with pointers.

This now matches the first two statements.